### PR TITLE
Add mechanism for selecting tests to run in stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,7 @@ task wrapper(type: Wrapper) {
     gradleVersion = '3.1'
 }
 
+task stageTest(type: Test) {
+    group = 'Verification'
+    systemProperty 'spock.configuration', 'StageSpockConfig.groovy'
+}

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/Stage.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/Stage.groovy
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Target([ElementType.TYPE, ElementType.METHOD])
+@Retention(RetentionPolicy.RUNTIME)
+@interface Stage {
+}

--- a/src/test/resources/StageSpockConfig.groovy
+++ b/src/test/resources/StageSpockConfig.groovy
@@ -1,0 +1,5 @@
+import uk.gov.justice.digital.hmpps.Stage
+
+runner {
+    include Stage
+}


### PR DESCRIPTION
Add @Stage annotation to specs (individual method or entire class) that should only run in stage.

In stage, set env var for 'spock.configuration' equal to 'StageSpockConfig.groovy', then only those tests run.

Can add other annotations and config when needed